### PR TITLE
appveyor CI 

### DIFF
--- a/MusicPlayer.sln
+++ b/MusicPlayer.sln
@@ -8,17 +8,23 @@ EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
 		Debug|x86 = Debug|x86
 		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
 		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{E56F6E12-089C-40ED-BCFD-923E5FA121A1}.Debug|Any CPU.ActiveCfg = Debug|x86
 		{E56F6E12-089C-40ED-BCFD-923E5FA121A1}.Debug|Any CPU.Build.0 = Debug|x86
+		{E56F6E12-089C-40ED-BCFD-923E5FA121A1}.Debug|x64.ActiveCfg = Debug|x64
+		{E56F6E12-089C-40ED-BCFD-923E5FA121A1}.Debug|x64.Build.0 = Debug|x64
 		{E56F6E12-089C-40ED-BCFD-923E5FA121A1}.Debug|x86.ActiveCfg = Debug|x86
 		{E56F6E12-089C-40ED-BCFD-923E5FA121A1}.Debug|x86.Build.0 = Debug|x86
 		{E56F6E12-089C-40ED-BCFD-923E5FA121A1}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{E56F6E12-089C-40ED-BCFD-923E5FA121A1}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E56F6E12-089C-40ED-BCFD-923E5FA121A1}.Release|x64.ActiveCfg = Release|x64
+		{E56F6E12-089C-40ED-BCFD-923E5FA121A1}.Release|x64.Build.0 = Release|x64
 		{E56F6E12-089C-40ED-BCFD-923E5FA121A1}.Release|x86.ActiveCfg = Release|x86
 		{E56F6E12-089C-40ED-BCFD-923E5FA121A1}.Release|x86.Build.0 = Release|x86
 	EndGlobalSection

--- a/MusicPlayer/Main.cs
+++ b/MusicPlayer/Main.cs
@@ -7,8 +7,6 @@ using System.Text;
 using System.Windows.Forms;
 using NppPluginNET;
 
-using System.Runtime.InteropServices;
-using System.Text;
 
 
 namespace MusicPlayer

--- a/MusicPlayer/MusicPlayer.csproj
+++ b/MusicPlayer/MusicPlayer.csproj
@@ -61,6 +61,15 @@
     <OutputPath>bin\x86\Release\</OutputPath>
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">
+    <DebugSymbols>true</DebugSymbols>
+    <OutputPath>bin\x64\Debug\</OutputPath>
+    <PlatformTarget>x64</PlatformTarget>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'">
+    <OutputPath>bin\x64\Release\</OutputPath>
+    <PlatformTarget>x64</PlatformTarget>
+  </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Drawing" />

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,62 @@
+version: 1.0.{build}
+image: Visual Studio 2015
+
+
+platform:
+    #- Any CPU
+    - x86
+    - x64
+
+configuration:
+    - Debug
+    - Release
+
+install:
+    - call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat"
+
+build:
+    parallel: true                  # enable MSBuild parallel builds
+    verbosity: minimal
+
+build_script:
+    - cd "%APPVEYOR_BUILD_FOLDER%"
+    - msbuild MusicPlayer.sln /m /p:configuration="%configuration%" /p:platform="%platform%"
+
+after_build:
+    - cd "%APPVEYOR_BUILD_FOLDER%"\MusicPlayer
+    - ps: >-
+
+        if ($env:PLATFORM -eq "x64") {
+            Push-AppveyorArtifact "bin\$($env:PLATFORM)\$($env:CONFIGURATION)\MusicPlayer.dll" -FileName MusicPlayer.dll
+        }
+
+        if ($env:PLATFORM -eq "x86" ) {
+            Push-AppveyorArtifact "bin\$($env:PLATFORM)\$($env:CONFIGURATION)\MusicPlayer.dll" -FileName MusicPlayer.dll
+        }
+
+        if ($($env:APPVEYOR_REPO_TAG) -eq "true" -and $env:CONFIGURATION -eq "Release") {
+            if($env:PLATFORM -eq "x64"){
+            $ZipFileName = "MusicPlayer_$($env:APPVEYOR_REPO_TAG_NAME)_x64.zip"
+            7z a $ZipFileName bin\$env:CONFIGURATION\MusicPlayer.dll
+            }
+            if($env:PLATFORM -eq "x86"){
+            $ZipFileName = "MusicPlayer_$($env:APPVEYOR_REPO_TAG_NAME)_x86.zip"
+            7z a $ZipFileName bin\$env:PLATFORM\$env:CONFIGURATION\MusicPlayer.dll
+            }
+        }
+
+artifacts:
+  - path: MusicPlayer_*.zip
+    name: releases
+
+deploy:
+    provider: GitHub
+    auth_token:
+        secure: !!TODO, see https://www.appveyor.com/docs/deployment/github/#provider-settings!!
+    artifact: releases
+    draft: false
+    prerelease: false
+    force_update: true
+    on:
+        appveyor_repo_tag: true
+        configuration: Release


### PR DESCRIPTION
- initial appveyor.yml CI config
- removed compiler warnings
- extended for x64 builds (, see https://notepad-plus-plus.org/community/topic/12633/npppluginnet-64-bit for the problems and changes needed), but probably not functional
- deployment to github needs security token see https://www.appveyor.com/docs/deployment/github/#provider-settings

Appveyor example build see: https://ci.appveyor.com/project/chcg/musicplayer/build/1.0.6
needs registration of this github project at appveyor